### PR TITLE
Stick motions can now cross the deadzone (if arpeggiated)

### DIFF
--- a/plover_controller/machine.py
+++ b/plover_controller/machine.py
@@ -381,8 +381,6 @@ class ControllerState:
 
     def maybe_complete_stroke(self):
         self.process_stick_movements()
-        if not self._unsequenced_buttons_and_hats and not self._pending_keys:
-            return
         if self.any_active_inputs():
             return
         keys = buttons_to_keys(


### PR DESCRIPTION
## Example mapping:
```
a -> A-
leftu -> S-
leftd -> T-
leftl -> P-
leftr -> H-

// Mappings that cross the deadzone
left(u,d) -> -F
left(l,r) -> -L
left(u,d,l,r) -> -Z
```

## Example motions and their outputs:
hold A + ↑ = SA-
hold A + ↑↓ = A-F
hold A + ↑↓← = PA-F
hold A + ↑↓←→ = A-Z
hold A + ←→↑↓ = A-FL
hold A + ←↑→↓ = STPHA-